### PR TITLE
Updated apiVersion and added spect.selector

### DIFF
--- a/manifests/statefulset.yaml
+++ b/manifests/statefulset.yaml
@@ -1,10 +1,13 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: $APP
 spec:
   serviceName: $APP
   replicas: 8
+  selector:
+    matchLabels:
+      app: rabbitmq
   template:
     metadata:
       labels:


### PR DESCRIPTION
added required spec.selector, updated apiVersion to apps/v1 to confirm to the updates in  k8 version 1.16

https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/